### PR TITLE
docs: Update VS Code extension changelog for tool name changes

### DIFF
--- a/docs/en-us/history-roadmap/changelogs/frontend/alpaca-vsc-extension.md
+++ b/docs/en-us/history-roadmap/changelogs/frontend/alpaca-vsc-extension.md
@@ -8,6 +8,10 @@
 
 All notable changes to the Visual Studio Code Extension (Preview)
 
+## v0.66.1 (2026-01-16)
+
+- Shorten language model tool names
+
 ## v0.66.0 (2026-01-15)
 
 - Add new actions for GitHub PRs to open PR Webview in VS Code and checking out PRs directly


### PR DESCRIPTION
Updates the changelog for the Visual Studio Code extension to document the shortening of language model tool names.

## Changes
- Added entry for tool name changes in the VS Code extension changelog
- Tools now use shorter names by removing API names and 'cosmo-alpaca-' prefix
- Example: `cosmo-alpaca-ContainerContainerApi-containerContainerCreateBcContainer` → `alpaca-containerContainerCreateBcContainer`

This aligns with the changes made in cosmoconsult/alpaca-vsc-extension.