### PR TITLE
Add changelog entry for v0.75.0

### DIFF
--- a/docs/en-us/history-roadmap/changelogs/backend/alpaca.md
+++ b/docs/en-us/history-roadmap/changelogs/backend/alpaca.md
@@ -8,7 +8,7 @@
 
 All notable changes to the Alpaca Backend
 
-## v0.75.0 (2026-01-21)
+## v0.75.0 (2026-01-22)
 
 - Add distributed Redis cache shared between Alpaca API instances
 


### PR DESCRIPTION
Added a new version entry for v0.75.0 with details about the distributed redis cache feature.