### PR TITLE
chore: update changelogs for alpaca-vsc-extension

### DIFF
--- a/docs/en-us/history-roadmap/changelogs/frontend/alpaca-vsc-extension.md
+++ b/docs/en-us/history-roadmap/changelogs/frontend/alpaca-vsc-extension.md
@@ -10,7 +10,7 @@ All notable changes to the Visual Studio Code Extension (Preview)
 
 ## v0.70.0 (2026-02-09)
 
-- Add support for creating GitHub containers for the project AL-Go settings (workflow unspecific)
+- Add support for creating GitHub containers for the project AL-Go settings (workflow-independent)
 
 ## v0.69.0 (2026-02-06)
 


### PR DESCRIPTION
[AB#4647](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4647)

Requires https://github.com/cosmoconsult/alpaca-vsc-extension/pull/227
