### PR TITLE
fix: Update artifact token for min version validation

### DIFF
--- a/docs/en-us/github/setup-workflows.md
+++ b/docs/en-us/github/setup-workflows.md
@@ -55,7 +55,7 @@ Repository example in `.github/AL-Go-Settings.json`:
         {
             "buildModes": ["MinVersion"],
             "settings": {
-                "artifact": "//*//first",
+                "artifact": "/OnPrem/*//first",
                 "nuGetFeedSelectMode": "EarliestMatching"
             }
         }


### PR DESCRIPTION
This pull request makes a small update to the documentation example for repository settings. The change updates the `artifact` path in the `.github/AL-Go-Settings.json` example to use a more specific path.

- Documentation update:
  * Changed the `artifact` value from `"//*//first"` to `"/OnPrem/*//first"` in the repository example in `docs/en-us/github/setup-workflows.md` to clarify the artifact path.