### PR TITLE
docs: add multi-country validation configuration to setup workflows

### DIFF
--- a/docs/en-us/github/setup-workflows.md
+++ b/docs/en-us/github/setup-workflows.md
@@ -78,7 +78,7 @@ Project example in `./**/.AL-Go/settings.json`:
 > [!NOTE]
 > `buildModes` is an array and arrays are merged by default in AL-Go. If you want a workflow to use only its own build modes, add `overwriteSettings` for `buildModes`.
 
-## How to configure multi country validation
+## How to configure multi-country validation
 
 Apps often need to be tested not just against one localization, but against several. AL-Go provides the [`additionalCountries`](https://aka.ms/algosettings#additionalCountries) property for this purpose. This is **not supported in COSMO Alpaca**. We can also handle this requirement using [`buildModes`](https://aka.ms/algosettings#buildModes) and [`ConditionalSettings`](https://aka.ms/algosettings#conditional-settings):
 

--- a/docs/en-us/github/setup-workflows.md
+++ b/docs/en-us/github/setup-workflows.md
@@ -78,6 +78,78 @@ Project example in `./**/.AL-Go/settings.json`:
 > [!NOTE]
 > `buildModes` is an array and arrays are merged by default in AL-Go. If you want a workflow to use only its own build modes, add `overwriteSettings` for `buildModes`.
 
+## How to configure multi country validation
+
+Apps often need to be tested not just against one localization, but against several. AL-Go provides the [`additionalCountries`](https://aka.ms/algosettings#additionalCountries) property for this purpose. This is **not supported in COSMO Alpaca**. We can also handle this requirement using [`buildModes`](https://aka.ms/algosettings#buildModes) and [`ConditionalSettings`](https://aka.ms/algosettings#conditional-settings):
+
+In the simplest case, we just add another buildMode called `ValidateDe` (the default must also be added so it isn’t lost) and use `ConditionalSettings` to change the country to be used for this mode. This causes the workflow to start a job for validation against `de` in parallel with the build against `w1`.
+
+Project example in `./**/.AL-Go/settings.json`
+
+```json
+{
+  "country": "w1",
+  "buildModes": [
+    "Default",
+    "ValidateDe"
+  ],
+  "ConditionalSettings": [
+    {
+      "buildModes": [
+        "ValidateDe"
+      ],
+      "settings": {
+        "country": "de"
+      }
+    }
+  ]
+}
+```
+
+If you take this example a step further, even more interesting possibilities emerge.
+For example, it’s possible to use country validation only for specific workflows (`CI/CD` and `Pull Request Build`, but not `Test Current`, `Test Next Minor` and `Test Next Major`) or, if a purely technical validation is sufficient, to skip the publishing and testing steps. This results in a significant speed boost when validating a country.
+
+Project example in `./**/.AL-Go/settings.json`
+
+```json
+{
+  "country": "w1",
+  "ConditionalSettings": [
+    {
+      "workflows": [
+        "CICD",
+        "Pull Request Build"
+      ],
+      "settings": {
+        "buildModes": [
+          "Default",
+          "ValidateDe",
+          "ValidateUs"
+        ]
+      }
+    },
+    {
+      "buildModes": [
+        "ValidateDe"
+      ],
+      "settings": {
+        "country": "de"
+      }
+    },
+    {
+      "buildModes": [
+        "ValidateUs"
+      ],
+      "settings": {
+        "country": "us",
+        "doNotPublishApps": true
+      }
+    }
+  ]
+}
+```
+
+
 ## Cron configuration example
 
 All of these workflows are scheduled through the workflow-specific setting `workflowSchedule`.


### PR DESCRIPTION
This pull request adds comprehensive documentation on configuring multi-country validation in AL-Go projects. The new section explains how to validate apps against multiple localizations using the `additionalCountries`, `buildModes`, and `ConditionalSettings` properties, and provides practical configuration examples.

**Multi-country validation documentation:**

* Added a new section, "How to configure multi country validation," to guide users on validating apps against several countries using `buildModes` and `ConditionalSettings` in `settings.json`.
* Included example configurations demonstrating:
  * Parallel validation jobs for different countries (e.g., `de`, `us`) using custom build modes.
  * Workflow-specific country validation and optimizations such as skipping publishing/testing steps for technical validation.
* Clarified that `additionalCountries` is not supported in COSMO Alpaca and provided alternative approaches.

[AB#4538](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4538)