### PR TITLE
Add instructions for merging Azure DevOps repositories into AL-Go

### DIFF
--- a/docs/en-us/github/migrate-from-azure-devops.md
+++ b/docs/en-us/github/migrate-from-azure-devops.md
@@ -433,3 +433,68 @@ Fields that were dropped:
 - `artifactsFeed`, `devopsPool` — Azure DevOps specific, not needed
 - `licenseFile` — BC 23+ uses Cronus by default; if needed, use `licenseFileUrlSecretName`
 - fileshare `url` — replaced with HTTPS URL
+
+## Merge multiple Azure DevOps Repositories into one multi project AL-Go repository
+
+In Azure DevOps, a repository was often created for each app, with one subfolder for the actual app and another for the test app.
+In AL-Go, it often makes sense to convert several of these repositories into one multi-project repository.
+If you want to [merge them without history](https://github.com/microsoft/AL-Go/blob/main/Scenarios/MigrateFromAzureDevOpsWithoutHistory.md), this can be easily done by simply copying the repositories together.
+
+However, if you want to preserve the history of both source repositories, this is also possible. To do this, first create and [initialize the destination repository](initialize-repository.md), and then merge the source repositories.
+
+> [!IMPORTANT]
+> The following procedure should be executed entirely locally or in a codespace and only pushed to GitHub after proper review.
+
+```powershell
+# Step 1: Clone the target repository
+$TargetRepoPath = "C:\git\TargetRepo" # adjust as needed
+Set-Location -Path $TargetRepoPath
+git clone https://github.com/[MyOrga]/[MyRepo].git .
+
+# Step 2: Add RepoA and fetch its history
+git remote add repoa "https://[MyOrga]@dev.azure.com/[MyOrga]/[MyProject]/_git/[MyRepoA]"
+git fetch repoa --tags
+
+# Step 3: Merge RepoA into projA subdirectory
+git merge -s ours --no-commit --allow-unrelated-histories repoa/main
+git read-tree --prefix=projA/ -u repoa/main # projA is the name of the AL-Go project folder
+git commit -m "Merge RepoA into projA subdirectory"
+
+# Step 4: Add RepoB and fetch its history
+git remote add repob "https://[MyOrga]@dev.azure.com/[MyOrga]/[MyProject]/_git/[MyRepoB]"
+git fetch repob --tags
+
+# Step 5: Merge RepoB into projB subdirectory
+git merge -s ours --no-commit --allow-unrelated-histories repob/main
+git read-tree --prefix=projB/ -u repob/main # projB is the name of the AL-Go project folder
+git commit -m "Merge RepoB into projB subdirectory"
+
+# Step 6: Verify the result
+git log --all --graph --oneline
+
+# Step 7: Remove remotes
+git remote remove repoa
+git remote remove repob
+
+# Step 8: Push to GitHub
+git push origin main --tags
+```
+
+It's possible that the `git log` won't resolve properly changes before the merge commit. However, `git blame` should provide the full history for all files.
+
+When pushing to GitHub, an error may occur if the repository history contains files larger than 100 MB. In this case, these files must be removed or managed using Git LFS.
+The files can be removed from the history using the following commands (requires Python and pip; use Codespace if necessary). The filenames can be found in the Git error message that appears during the push. Warning: This changes the commit history and should only be done if absolutely necessary. As always, test and verify locally first before pushing the changes to GitHub.
+
+```powershell
+# Step 1: Install git-filter-repo if not already installed
+python -m pip install git-filter-repo
+
+# Step 2: Remove large files from history
+git filter-repo --path migration/Export-NAVObjects/01_NavBaseObjects.txt --invert-paths
+git filter-repo --path migration/Export-NAVObjects/02_NavModuleObjects.txt --invert-paths # Repeat for each large file
+
+#Step 3: Add origin remote and push to GitHub
+git remote add origin https://github.com/[MyOrga]/[MyRepo].git
+git push origin --force --all
+git push origin --force --tags
+```

--- a/docs/en-us/github/migrate-from-azure-devops.md
+++ b/docs/en-us/github/migrate-from-azure-devops.md
@@ -480,18 +480,11 @@ git remote remove repob
 git push origin main --tags
 ```
 
-It's possible that the `git log` won't resolve properly changes before the merge commit. However, `git blame` should provide the full history for all files.
+It's possible that the `git log` may not properly show changes before the merge commit. However, `git blame` should provide the full history for all files.
 
 When pushing to GitHub, an error may occur if the repository history contains files larger than 100 MB. In this case, these files must be removed or managed using Git LFS.
-The files can be removed from the history using the following commands (requires Python and pip; use Codespace if necessary). The filenames can be found in the Git error message that appears during the push. Warning: This changes the commit history and should only be done if absolutely necessary. As always, test and verify locally first before pushing the changes to GitHub.
+The files can be removed from the history using the following commands (requires Python and pip; use Codespace if necessary). The filenames can be found in the Git error message that appears during the push. Warning: This changes the commit history and should only be done if absolutely necessary. Because these steps are run in an existing working repository rather than in a fresh clone, `git filter-repo` may otherwise refuse to run with a safety error. In this specific situation, `--force` is required because you are intentionally rewriting the local history before pushing the migrated repository to GitHub. As always, test and verify locally first before pushing the changes to GitHub.
 
-```powershell
-# Step 1: Install git-filter-repo if not already installed
-python -m pip install git-filter-repo
-
-# Step 2: Remove large files from history
-git filter-repo --path migration/Export-NAVObjects/01_NavBaseObjects.txt --invert-paths
-git filter-repo --path migration/Export-NAVObjects/02_NavModuleObjects.txt --invert-paths # Repeat for each large file
 
 #Step 3: Add origin remote and push to GitHub
 git remote add origin https://github.com/[MyOrga]/[MyRepo].git

--- a/docs/en-us/github/migrate-from-azure-devops.md
+++ b/docs/en-us/github/migrate-from-azure-devops.md
@@ -434,7 +434,7 @@ Fields that were dropped:
 - `licenseFile` — BC 23+ uses Cronus by default; if needed, use `licenseFileUrlSecretName`
 - fileshare `url` — replaced with HTTPS URL
 
-## Merge multiple Azure DevOps Repositories into one multi project AL-Go repository
+## Merge multiple Azure DevOps repositories into one multi-project AL-Go repository
 
 In Azure DevOps, a repository was often created for each app, with one subfolder for the actual app and another for the test app.
 In AL-Go, it often makes sense to convert several of these repositories into one multi-project repository.


### PR DESCRIPTION
This pull request adds detailed documentation for merging multiple Azure DevOps repositories into a single multi-project AL-Go repository, covering both history-preserving and non-history-preserving approaches. The new section provides step-by-step instructions, including handling large files that may block a push to GitHub.

### Documentation improvements

* Added a comprehensive guide to `migrate-from-azure-devops.md` for merging multiple Azure DevOps repositories into one AL-Go repository, including both merging with and without preserving history.
* Included PowerShell scripts and important warnings for safely merging repositories and removing large files from history using `git-filter-repo`.
* Provided troubleshooting advice for issues with large files when pushing to GitHub and instructions for using Git LFS or removing files from history.

[AB#4821](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4821)