### PR TITLE
chore: improve GitHub docs

### DIFF
--- a/docs/en-us/github/interact-with-requirements.md
+++ b/docs/en-us/github/interact-with-requirements.md
@@ -12,7 +12,7 @@ With GitHub you can either use the GitHub issues to track your requirements or y
 To connect a GitHub repository to an Azure DevOps project you need to [set up the connection](https://learn.microsoft.com/en-us/azure/devops/boards/github/install-github-app?view=azure-devops#add-or-remove-repositories-or-remove-a-connection-from-azure-boards) first.
 
 > [!NOTE]
-> For COSMO repositories, the part "Change repository access" by configuring the GitHub app can be skipped, as the necessary permissions are already set for all repositories within the **cosmconsult** organization.
+> For **COSMO** repositories, the part "Change repository access" by configuring the GitHub app can be skipped as the necessary permissions are already set for all repositories within the **cosmconsult** organization.
 
 Afterwards you can use the following ways to link code changes in your GitHub repositories to WorkItems in Azure DevOps:
 - When you start working on a WorkItem, you can [create a new branch directly from the WorkItem](https://learn.microsoft.com/en-us/azure/devops/release-notes/roadmap/2024/github-branch).

--- a/docs/en-us/github/interact-with-requirements.md
+++ b/docs/en-us/github/interact-with-requirements.md
@@ -12,7 +12,7 @@ With GitHub you can either use the GitHub issues to track your requirements or y
 To connect a GitHub repository to an Azure DevOps project you need to [set up the connection](https://learn.microsoft.com/en-us/azure/devops/boards/github/install-github-app?view=azure-devops#add-or-remove-repositories-or-remove-a-connection-from-azure-boards) first.
 
 > [!NOTE]
-> For **COSMO** repositories, the part "Change repository access" by configuring the GitHub app can be skipped as the necessary permissions are already set for all repositories within the **cosmconsult** organization.
+> For **COSMO** repositories, the part "Change repository access" by configuring the GitHub app can be skipped as the necessary permissions are already set for all repositories within the **cosmoconsult** organization.
 
 Afterwards you can use the following ways to link code changes in your GitHub repositories to WorkItems in Azure DevOps:
 - When you start working on a WorkItem, you can [create a new branch directly from the WorkItem](https://learn.microsoft.com/en-us/azure/devops/release-notes/roadmap/2024/github-branch).

--- a/docs/en-us/github/interact-with-requirements.md
+++ b/docs/en-us/github/interact-with-requirements.md
@@ -5,16 +5,18 @@
 
 # Work with Issues and Work Items
 
-With GitHub you can either use the GitHub issues to track your requirements or you can use the Azure Boards integration to use WorkItems in Azure DevOps. 
+With GitHub you can either use the GitHub issues to track your requirements or you can use the Azure Boards integration to use WorkItems in Azure DevOps.
 
 ## Azure DevOps WorkItems
 
 To connect a GitHub repository to an Azure DevOps project you need to [set up the connection](https://learn.microsoft.com/en-us/azure/devops/boards/github/install-github-app?view=azure-devops#add-or-remove-repositories-or-remove-a-connection-from-azure-boards) first.
 
+> [!NOTE]
+> For COSMO repositories, the part "Change repository access" by configuring the GitHub app can be skipped, as the necessary permissions are already set for all repositories within the **cosmconsult** organization.
+
 Afterwards you can use the following ways to link code changes in your GitHub repositories to WorkItems in Azure DevOps:
 - When you start working on a WorkItem, you can [create a new branch directly from the WorkItem](https://learn.microsoft.com/en-us/azure/devops/release-notes/roadmap/2024/github-branch).
 - When you make a change in your code and want to connect that change to a WorkItem, you can do that by [using `AB#<id>` with the ID of the relevant WorkItem](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops) in your commit message or Pull Request description.
-
 
 ## GitHub Issues
 

--- a/docs/en-us/github/walkthrough.md
+++ b/docs/en-us/github/walkthrough.md
@@ -15,7 +15,7 @@ Before starting with the walkthrough, let's set up our tooling.
 1. [Set up VS Code and the COSMO Alpaca Extension](../getting-started/setup-vsce.md)
 
 > [!IMPORTANT]
-> **COSMO** users don't have to create a GitHub organization as all repositories are to be created within the **cosmconsult** organization.
+> **COSMO** users don't have to create a GitHub organization as all repositories are to be created within the **cosmoconsult** organization.
 
 ## Create your first app and requirement
 

--- a/docs/en-us/github/walkthrough.md
+++ b/docs/en-us/github/walkthrough.md
@@ -14,13 +14,16 @@ Before starting with the walkthrough, let's set up our tooling.
 1. [Sign up and create an GitHub organization](create-org.md)
 1. [Set up VS Code and the COSMO Alpaca Extension](../getting-started/setup-vsce.md)
 
+> [!IMPORTANT]
+> **COSMO** users don't have to create a GitHub organization as all repositories are to be created within the **cosmconsult** organization.
+
 ## Create your first app and requirement
 
 Imagine you're the project manager or lead developer and you have a new customer. You now prepare the new project and set up the new repository for that customer via VS Code and create the first requirement:
 
-2. [Create repository, AL App and workflows](create-app.md)
+1. [Create repository, AL App and workflows](create-app.md)
 1. [Create a AL-Go project](create-project.md) (optional, only needed for multi-project repositories)
-3. [Open your project/repository in the browser](../shared/open-stuff.md) and create a new issue/workitem that you'll be working on next
+1. [Open your project/repository in the browser](../shared/open-stuff.md) and create a new issue/workitem that you'll be working on next
 
 ## Implementing your first requirement
 


### PR DESCRIPTION
This pull request updates documentation to clarify organization-specific setup steps for COSMO users and improves the walkthrough instructions. The main changes ensure COSMO users have clear guidance and avoid unnecessary steps when connecting repositories or following the setup walkthrough.

**COSMO-specific documentation clarifications:**

* Added a note to `interact-with-requirements.md` stating that COSMO users can skip the "Change repository access" step when configuring the GitHub app, as permissions are already set for all repositories in the `cosmconsult` organization.
* Added an important notice to `walkthrough.md` indicating that COSMO users do not need to create a new GitHub organization, since all repositories should be created within the `cosmconsult` organization.

**Walkthrough improvements:**

* Fixed step numbering in the setup instructions to ensure clarity and correct order for creating repositories, AL Apps, and opening projects/issues.

fixes [AB#4855](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4855)