### PR TITLE
docs: add Preconfigured Build Modes documentation and update references

### DIFF
--- a/docs/en-us/github/index.md
+++ b/docs/en-us/github/index.md
@@ -33,7 +33,7 @@ Collaborate on the Business Central base app with other teams and contributors.
 
 ### COSMO-only Features
 
-Internal features for COSMO CONSULT teams, including assigning organizations to COSMO entities for internal tracking.
+Internal features for COSMO CONSULT teams, including [preconfigured build modes](preconfigured-build-modes.md) for conditional workflow behavior and assigning organizations to COSMO entities for internal tracking.
 
 ## Prerequisites
 

--- a/docs/en-us/github/preconfigured-build-modes.md
+++ b/docs/en-us/github/preconfigured-build-modes.md
@@ -1,0 +1,64 @@
+---
+    title: Preconfigured Build Modes (COSMO-only)
+    description: Preconfigured AL-Go build modes in COSMO repositories and how to combine them
+---
+
+# Preconfigured Build Modes (COSMO-only)
+
+This page documents the **preconfigured AL-Go build modes** used in COSMO GitHub repositories.
+
+These settings are implemented through `ConditionalSettings` and allow you to compose build behavior by combining mode tokens in a single build mode name.
+
+> [!IMPORTANT]
+> This behavior is **COSMO-only** and intended for repositories/templates that are in COSMO GitHub organizations.
+
+## Supported preconfigured mode tokens
+
+### Behavior tokens
+
+- `nocontainer` -> sets `doNotPublishApps: true`
+- `minversion` -> sets `artifact: /onprem/*//first`
+
+### Country tokens
+
+Use one of these as `country:<code>`:
+
+- `at`, `au`, `base`, `be`, `bg`, `br`, `ca`, `ch`, `co`, `cz`, `de`, `dk`, `ee`, `es`, `fi`, `fr`, `gb`, `gr`, `hk`, `hr`, `hu`, `ie`, `in`, `is`, `it`, `jp`, `kr`, `lt`, `lv`, `mx`, `nl`, `no`, `nz`, `pe`, `ph`, `pl`, `pt`, `ro`, `rs`, `se`, `si`, `sk`, `th`, `tr`, `tw`, `ua`, `us`, `vn`, `w1`
+
+## How combinations work
+
+The wildcard patterns allow token matching at the start, middle, or end of the build mode string.
+
+That means you can define combined build modes such as:
+
+- `nocontainer-minversion-country:de`
+- `country:us-minversion`
+- `featureX-country:at-nocontainer`
+
+If a combined build mode matches multiple conditional blocks, AL-Go applies all matching settings.
+
+## Example
+
+Example in `./**/.AL-Go/settings.json`:
+
+```json
+{
+  "buildModes": [
+    "Default",
+    "nocontainer-minversion-country:de",
+    "country:us"
+  ]
+}
+```
+
+Result for `nocontainer-minversion-country:de`:
+
+- `doNotPublishApps: true`
+- `artifact: /onprem/*//first`
+- `country: de`
+
+## Notes
+
+- Keep build mode names token-based and hyphen-separated for readability.
+- Use exactly one `country:<code>` token per combined mode to avoid conflicting country assignments.
+- For generic AL-Go behavior, see the Microsoft docs for [`buildModes`](https://aka.ms/algosettings#buildModes) and [`ConditionalSettings`](https://aka.ms/algosettings#conditional-settings).

--- a/docs/en-us/github/preconfigured-build-modes.md
+++ b/docs/en-us/github/preconfigured-build-modes.md
@@ -17,7 +17,8 @@ These settings are implemented through `ConditionalSettings` and allow you to co
 ### Behavior tokens
 
 - `nocontainer` -> sets `doNotPublishApps: true`
-- `minversion` -> sets `artifact: /onprem/*//first`
+- `minversion` or `minversion:sandbox` -> sets `artifact: /sandbox/*//first` and `nuGetFeedSelectMode: EarliestMatching`
+- `minversion:onprem` -> sets `artifact: /onprem/*//first` and `nuGetFeedSelectMode: EarliestMatching`
 
 ### Country tokens
 
@@ -32,7 +33,8 @@ The wildcard patterns allow token matching at the start, middle, or end of the b
 That means you can define combined build modes such as:
 
 - `nocontainer-minversion-country:de`
-- `country:us-minversion`
+- `country:us-minversion:sandbox`
+- `country:gb-minversion:onprem`
 - `featureX-country:at-nocontainer`
 
 If a combined build mode matches multiple conditional blocks, AL-Go applies all matching settings.
@@ -46,6 +48,7 @@ Example in `./**/.AL-Go/settings.json`:
   "buildModes": [
     "Default",
     "nocontainer-minversion-country:de",
+    "country:gb-minversion:onprem",
     "country:us"
   ]
 }
@@ -54,8 +57,15 @@ Example in `./**/.AL-Go/settings.json`:
 Result for `nocontainer-minversion-country:de`:
 
 - `doNotPublishApps: true`
-- `artifact: /onprem/*//first`
+- `artifact: /sandbox/*//first`
+- `nuGetFeedSelectMode: EarliestMatching`
 - `country: de`
+
+Result for `country:gb-minversion:onprem`:
+
+- `artifact: /onprem/*//first`
+- `nuGetFeedSelectMode: EarliestMatching`
+- `country: gb`
 
 ## Notes
 

--- a/docs/en-us/github/setup-workflows.md
+++ b/docs/en-us/github/setup-workflows.md
@@ -149,6 +149,8 @@ Project example in `./**/.AL-Go/settings.json`
 }
 ```
 
+This can also be solved by using [Preconfigured Build Modes (COSMO-only)](preconfigured-build-modes.md).
+
 
 ## Cron configuration example
 
@@ -173,6 +175,7 @@ You can set up schedules for each of these workflows independently using their r
 
 Relevant docs:
 
+- [Preconfigured Build Modes (COSMO-only)](preconfigured-build-modes.md)
 - [AL-Go `workflowSchedule`](https://aka.ms/algosettings#workflow-specific-settings)
 - [Update AL-Go system files](https://github.com/microsoft/AL-Go/blob/main/Scenarios/UpdateAlGoSystemFiles.md)
 - [crontab.guru](https://crontab.guru/)

--- a/docs/en-us/toc.md
+++ b/docs/en-us/toc.md
@@ -130,6 +130,8 @@
 
 ### [Assign Organization to Entity](github/assign-entity.md)
 
+### [Preconfigured Build Modes](github/preconfigured-build-modes.md)
+
 # [Azure DevOps](azure-devops/index.md)
 
 ## [Walkthrough](azure-devops/walkthrough.md)


### PR DESCRIPTION
This pull request adds documentation for COSMO-only preconfigured build modes in AL-Go, making it easier for COSMO teams to understand and configure conditional workflow behavior using build mode tokens. The documentation explains available tokens, how to combine them, and provides usage examples. References to this new documentation are added in relevant places across the docs.

**Documentation Additions:**

* Added a new page, `preconfigured-build-modes.md`, detailing COSMO-only preconfigured AL-Go build modes, supported tokens, combination rules, and examples.
* Updated the table of contents (`toc.md`) to include the new Preconfigured Build Modes documentation.

**Documentation Updates and Cross-References:**

* Updated the COSMO-only features section in `index.md` to mention preconfigured build modes and link to the new documentation.
* Added references to the new Preconfigured Build Modes documentation in `setup-workflows.md`, both after the build mode example and in the relevant docs section. [[1]](diffhunk://#diff-fff4768eca22f8e6ff651a7481d73b681a82d628324fb28c646d2be02e1d4f7aR152-R153) [[2]](diffhunk://#diff-fff4768eca22f8e6ff651a7481d73b681a82d628324fb28c646d2be02e1d4f7aR178)

[AB#4825](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4825)