### PR TITLE
fix: Reorder and remove country tokens in documentation

### DIFF
--- a/docs/en-us/github/preconfigured-build-modes.md
+++ b/docs/en-us/github/preconfigured-build-modes.md
@@ -24,7 +24,7 @@ These settings are implemented through `ConditionalSettings` and allow you to co
 
 Use one of these as `country:<code>`:
 
-- `w1`, `base`, `at`, `au`, `be`, `ca`, `ch`, `cz`, `de`, `dk`, `dk`, `dk`, `es`, `fi`, `fr`, `gb`, `in`, `is`, `it`, `mx`, `nl`, `no`, `nz`, `ru`, `se`, `us`
+- `w1`, `base`, `at`, `au`, `be`, `ca`, `ch`, `cz`, `de`, `dk`, `es`, `fi`, `fr`, `gb`, `in`, `is`, `it`, `mx`, `nl`, `no`, `nz`, `ru`, `se`, `us`
 
 ## How combinations work
 

--- a/docs/en-us/github/preconfigured-build-modes.md
+++ b/docs/en-us/github/preconfigured-build-modes.md
@@ -24,7 +24,7 @@ These settings are implemented through `ConditionalSettings` and allow you to co
 
 Use one of these as `country:<code>`:
 
-- `at`, `au`, `base`, `be`, `bg`, `br`, `ca`, `ch`, `co`, `cz`, `de`, `dk`, `ee`, `es`, `fi`, `fr`, `gb`, `gr`, `hk`, `hr`, `hu`, `ie`, `in`, `is`, `it`, `jp`, `kr`, `lt`, `lv`, `mx`, `nl`, `no`, `nz`, `pe`, `ph`, `pl`, `pt`, `ro`, `rs`, `se`, `si`, `sk`, `th`, `tr`, `tw`, `ua`, `us`, `vn`, `w1`
+- `w1`, `base`, `at`, `au`, `be`, `ca`, `ch`, `cz`, `de`, `dk`, `dk`, `dk`, `es`, `fi`, `fr`, `gb`, `in`, `is`, `it`, `mx`, `nl`, `no`, `nz`, `ru`, `se`, `us`
 
 ## How combinations work
 


### PR DESCRIPTION
This pull request updates the documentation for preconfigured build modes by modifying the list of supported country codes in the `docs/en-us/github/preconfigured-build-modes.md` file. The main change is a reordering and adjustment of the country codes to reflect the currently supported set.

Documentation update:

* Updated the list of valid `country:<code>` options, changing the order, removing some codes in `preconfigured-build-modes.md`.