### PR TITLE
docs: Enhance migration guide with AL-Go settings and examples

### DIFF
--- a/docs/en-us/github/migrate-from-azure-devops.md
+++ b/docs/en-us/github/migrate-from-azure-devops.md
@@ -312,9 +312,9 @@ The fields are the same, but they move under the `alpaca` key.
 
 | cosmo.json field | AL-Go setting | Notes |
 | - | - | - |
-| `codeCops` | `enableCodeCop`, `enableUICop`, `customCodeCops` | AL-Go uses individual boolean flags plus an array for custom cops |
-| `rulesetFile` | `rulesetFile` | Same concept |
-| `compilerVsixVersion` | `vsixFile` | Values differ: `container`→`default`, `latest`→`latest`, `prerelease`→`preview` |
+| `codeCops` | [`enableCodeCop`](https://aka.ms/algosettings#enableCodeCop), [`enableUICop`](https://aka.ms/algosettings#enableUICop), [`enablePerTenantExtensionCop`](https://aka.ms/algosettings#enablePerTenantExtensionCop), [`enableAppSourceCop`](https://aka.ms/algosettings#enableAppSourceCop), [`customCodeCops`](https://aka.ms/algosettings#customCodeCops) | AL-Go uses individual boolean flags plus an array for custom cops |
+| `rulesetFile` | [`rulesetFile`](https://aka.ms/algosettings#rulesetFile) | Same concept but the path must be relative to the project root |
+| `compilerVsixVersion` | [`vsixFile`](https://aka.ms/algosettings#vsixFile) | Values differ: `container`→`default`, `latest`→`latest`, `prerelease`→`preview` |
 
 ### Versioning
 
@@ -326,8 +326,8 @@ The fields are the same, but they move under the `alpaca` key.
 
 | cosmo.json field | AL-Go setting | Notes |
 | - | - | - |
-| `enablePremium` | `assignPremiumPlan` | Same intent |
-| `importTestApps` | `installTestFramework` / `installTestRunner` | AL-Go has separate flags |
+| `enablePremium` | [`assignPremiumPlan`](https://aka.ms/algosettings#assignPremiumPlan) | Same intent |
+| `importTestApps` | [`installTestFramework`](https://aka.ms/algosettings#installTestFramework) / [`installTestRunner`](https://aka.ms/algosettings#installTestRunner) | AL-Go has separate flags |
 
 ## Full migration example
 
@@ -350,7 +350,16 @@ The fields are the same, but they move under the `alpaca` key.
             "authToken": "$(MyFeedPAT)"
         }
     ],
-
+    "artifacts": [
+        {
+            "name": "My-Custom-Fonts",
+            "url": "https://my.blob.core.windows.net/anypath/fonts.zip?sp=***",
+            "target": "fonts",
+            "ignoreIn": [
+                "build"
+            ]
+        }
+    ],
     "bcArtifacts": {
         "current": {
             "country": "de",
@@ -411,7 +420,15 @@ The fields are the same, but they move under the `alpaca` key.
             },
             {
                 "name": "Contoso.MyTestLibrary.f1e2d3c4-b5a6-7890-dcba-0987654321fe"
-            }
+            },
+            {
+                "name": "My-Custom-Fonts",
+                "url": "https://my.blob.core.windows.net/anypath/fonts.zip?sp=***",
+                "target": "fonts",
+                "ignoreIn": [
+                    "build"
+                ]
+        }
         ]
     }
 }
@@ -429,10 +446,22 @@ The fields are the same, but they move under the `alpaca` key.
 > The `nextMajor` configuration in `cosmo.json` used a version. In AL-Go, `nextMajor` is handled via the `select` segment of the artifact string without a specific version.
 
 Fields that were dropped:
-
-- `artifactsFeed`, `devopsPool` — Azure DevOps specific, not needed
+- `dockerSwarmUrl`, `dockerParamsForBuild` — COSMO backend build infrastructure settings are not used in GitHub Actions
+- `artifactsFeed`, `artifactsScope`, `artifactsPackageName`, `devopsPool`, `publishArtifactOnCompile`, `enableCompilerOutput`, `publishToFolderStructure` — Azure DevOps specific, not needed
 - `licenseFile` — BC 23+ uses Cronus by default; if needed, use `licenseFileUrlSecretName`
 - fileshare `url` — replaced with HTTPS URL
+- `testSuite` — AL-Go executes all tests from included test apps by default
+- `downloadSourcePreviousRelease` — AL-Go downloads previous versions from NuGet feeds, so this setting is not applicable
+- `customNavSettings` — no direct equivalent; If settings are required, try to use [BcContainerHelper setting](https://aka.ms/algosettings#bccontainerhelper-settings) to set environment Variables.
+    ```json
+    {
+        "DefaultNewContainerParameters": {
+            "additionalParameters": "-e CustomNavSettings=DisableWriteInsideTryFunctions=false"
+        }
+    }
+    ```
+    **Note:** TaskScheduler is enabled by default for dev containers and disabled by default for build containers.
+- `appImportSuppressWarnings` — AL-Go does not have a direct equivalent
 
 ## Merge multiple Azure DevOps repositories into one multi-project AL-Go repository
 

--- a/docs/en-us/github/migrate-from-azure-devops.md
+++ b/docs/en-us/github/migrate-from-azure-devops.md
@@ -428,7 +428,7 @@ The fields are the same, but they move under the `alpaca` key.
                 "ignoreIn": [
                     "build"
                 ]
-        }
+            }
         ]
     }
 }
@@ -452,7 +452,7 @@ Fields that were dropped:
 - fileshare `url` — replaced with HTTPS URL
 - `testSuite` — AL-Go executes all tests from included test apps by default
 - `downloadSourcePreviousRelease` — AL-Go downloads previous versions from NuGet feeds, so this setting is not applicable
-- `customNavSettings` — no direct equivalent; If settings are required, try to use [BcContainerHelper setting](https://aka.ms/algosettings#bccontainerhelper-settings) to set environment Variables.
+- `customNavSettings` — no direct equivalent; if settings are required, try to use [BcContainerHelper settings](https://aka.ms/algosettings#bccontainerhelper-settings) to set environment variables.
     ```json
     {
         "DefaultNewContainerParameters": {


### PR DESCRIPTION
This pull request updates the migration guide from Azure DevOps to AL-Go, expanding documentation and clarifying the mapping of configuration fields. The main improvements include adding documentation links for AL-Go settings, updating notes for better accuracy, providing a more complete migration example, and clarifying which legacy fields are no longer relevant.

**Documentation improvements:**

* Added direct links to the AL-Go settings documentation for each mapped setting in the configuration mapping tables, and clarified notes about path requirements and value differences. [[1]](diffhunk://#diff-247bf4d4955252568c10ba352c123f37de1c50593f1d1402e2bfba4c16c14fa3L315-R317) [[2]](diffhunk://#diff-247bf4d4955252568c10ba352c123f37de1c50593f1d1402e2bfba4c16c14fa3L329-R330)
* Improved the migration example by including an `artifacts` section and showing how to define a custom artifact, both in the main configuration and in the test apps list. [[1]](diffhunk://#diff-247bf4d4955252568c10ba352c123f37de1c50593f1d1402e2bfba4c16c14fa3L353-R362) [[2]](diffhunk://#diff-247bf4d4955252568c10ba352c123f37de1c50593f1d1402e2bfba4c16c14fa3R423-R430)

**Clarification of deprecated or changed fields:**

* Expanded the list of dropped or changed fields, explaining which Azure DevOps or COSMO-specific settings are no longer applicable, and providing alternatives or notes where relevant (e.g., for `customNavSettings` and `testSuite`).