### PR TITLE
fix wording on configuration package

### DIFF
--- a/docs/en-us/admin/index.md
+++ b/docs/en-us/admin/index.md
@@ -57,7 +57,7 @@ A package in the artifact feed must have the following folder structure:
 ![Folder Structure](../media/pipelines/ip-feed-folder-structure.png)
 
 > [!IMPORTANT]
-> For now, you only get the full app with type "app", but in the future test apps, rapidstart packages or runtime packages might follow.
+> For now, you only get the full app with type "app", but in the future test apps, configuration packages (rapidstart) or runtime packages might follow.
 
 ## Configuring your backend for AAD authentication
 


### PR DESCRIPTION
This pull request updates the documentation to clarify the types of packages that may be available in the artifact feed in the future. It now specifies that configuration packages (rapidstart) could be included, in addition to test apps and runtime packages.

Documentation clarification:

* Updated the note in `docs/en-us/admin/index.md` to mention configuration packages (rapidstart) as a possible future package type in the artifact feed.