### PR TITLE
Update migration notes for AL-Go to COSMO Alpaca transition

### DIFF
--- a/docs/en-us/github/migrate-from-al-go.md
+++ b/docs/en-us/github/migrate-from-al-go.md
@@ -11,7 +11,7 @@ Use this migration if your repository is already on **GitHub** and already uses 
 
 
 > [!WARNING]
-> AL-Go currently does not reliably support customer templates layered on top of COSMO Alpaca templates. If custom templates are added on top, not all COSMO Alpaca settings are inherited correctly into the repositories.
+> AL-Go currently does not reliably support custom templates layered on top of COSMO Alpaca templates. If you add custom templates, repositories might not inherit all COSMO Alpaca settings correctly.
 
 ## What changes when switching
 

--- a/docs/en-us/github/migrate-from-al-go.md
+++ b/docs/en-us/github/migrate-from-al-go.md
@@ -10,8 +10,8 @@ This page explains how to take an existing GitHub repository that already uses M
 Use this migration if your repository is already on **GitHub** and already uses AL-Go, but you now want to use COSMO Alpaca features such as managed repository standards, COSMO Alpaca workflow extensions, and cloud-hosted development containers.
 
 
-> [!NOTE]
-> If the repository already uses a custom template, you must migrate that custom template first. After that, an initialization and a normal update are enough.
+> [!WARNING]
+> AL-Go currently does not reliably support customer templates layered on top of COSMO Alpaca templates. If custom templates are added on top, not all COSMO Alpaca settings are inherited correctly into the repositories.
 
 ## What changes when switching
 


### PR DESCRIPTION
This pull request updates the migration documentation for repositories using AL-Go on GitHub. The main change is a clarification and strengthening of the warning regarding the use of custom templates layered on top of COSMO Alpaca templates.

Documentation updates:

* Updated the migration note to a warning, clarifying that AL-Go does not reliably support custom templates layered on COSMO Alpaca templates, and that not all settings may be inherited correctly.