### PR TITLE
docs: add section on handling missing test cases in AL-Go settings

### DIFF
--- a/docs/en-us/github/setup-al-go-settings.md
+++ b/docs/en-us/github/setup-al-go-settings.md
@@ -174,7 +174,7 @@ Settings to control the behavior if a test run finishes without any `testcase` e
 
 | Element | Type | Default | Scope | Value |
 | - | - | - | - | - |
-| `alpaca` > `ActionOnMissingTests` | string | `Warning` | workflow | Controls how missing test cases are handled in the build workflow. Allowed values: `None`, `Warning`, `Error`. <br>`None`: skip the check. <br>`Warning`: log a warning and continue. <br>`Error`: fail the workflow step with an error. |
+| `alpaca` > `actionOnMissingTests` | string | `Warning` | workflow | Controls how missing test cases are handled in the build workflow. Allowed values: `None`, `Warning`, `Error`. <br>`None`: skip the check. <br>`Warning`: log a warning and continue. <br>`Error`: fail the workflow step with an error. |
 
 ## Migrating from alpaca.json
 

--- a/docs/en-us/github/setup-al-go-settings.md
+++ b/docs/en-us/github/setup-al-go-settings.md
@@ -170,7 +170,7 @@ Settings to change the behavior of the breaking change check of the build workfl
 
 ### Action on Missing Test Cases
 
-Settings to control the behavior if a test run finishes without any `testcase` entry in the JUnit result file.
+Settings to control the behavior if a test apps are executed but no test result is found. This may be the case if none of the test apps have test cases or if all of them have been ignored.
 
 | Element | Type | Default | Scope | Value |
 | - | - | - | - | - |

--- a/docs/en-us/github/setup-al-go-settings.md
+++ b/docs/en-us/github/setup-al-go-settings.md
@@ -168,6 +168,14 @@ Settings to change the behavior of the breaking change check of the build workfl
 | - | - | - | - | - |
 | `alpaca` > `useNuGetFeedsForUpgrade` | boolean | `false` | workflow | Set `true` to test for breaking changes by downloading previous app versions from the trusted NuGet feeds rather than from the assets of the latest GitHub release. |
 
+### Action on Missing Test Cases
+
+Settings to control the behavior if a test run finishes without any `testcase` entry in the JUnit result file.
+
+| Element | Type | Default | Scope | Value |
+| - | - | - | - | - |
+| `alpaca` > `ActionOnMissingTests` | string | `Warning` | workflow | Controls how missing test cases are handled in the build workflow. Allowed values: `None`, `Warning`, `Error`. <br>`None`: skip the check. <br>`Warning`: log a warning and continue. <br>`Error`: fail the workflow step with an error. |
+
 ## Migrating from alpaca.json
 
 Migrate and remove existing *alpaca.json* files.


### PR DESCRIPTION
This pull request updates the documentation to add a new setting for handling missing test cases in the build workflow. The main change is the introduction of the `ActionOnMissingTests` setting, which allows users to control how the workflow responds when no test cases are found in the JUnit result file.

**New workflow configuration:**

* Added documentation for the `alpaca > ActionOnMissingTests` setting, allowing users to specify how missing test cases are handled (`None`, `Warning`, or `Error`). This setting determines whether the workflow skips the check, logs a warning, or fails with an error when no test cases are found.

[AB#4946](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4946)