### PR TITLE
docs: add code analyzer settings for test apps in AL-Go documentation

### DIFF
--- a/docs/en-us/github/setup-al-go-settings.md
+++ b/docs/en-us/github/setup-al-go-settings.md
@@ -178,12 +178,12 @@ Settings to override code analyzer settings for test apps and BCPT apps.
 
 | Element | Type | Default | Scope | Value |
 | - | - | - | - | - |
-| `alpaca` > `enableCodeCopForTestApps` | boolean | [`enableCodeCop`](https://aka.ms/algosettings#enableCodeCop) | workflow | Overrides `enableCodeCop` for test app builds. |
-| `alpaca` > `enableUICopForTestApps` | boolean | [`enableUICop`](https://aka.ms/algosettings#enableUICop) | workflow | Overrides `enableUICop` for test app builds. |
-| `alpaca` > `enablePerTenantExtensionCopForTestApps` | boolean | [`enablePerTenantExtensionCop`](https://aka.ms/algosettings#enablePerTenantExtensionCop) | workflow | Overrides `enablePerTenantExtensionCop` for test app builds. |
-| `alpaca` > `enableAppSourceCopForTestApps` | boolean | [`enableAppSourceCop`](https://aka.ms/algosettings#enableAppSourceCop) | workflow | Overrides `enableAppSourceCop` for test app builds. |
-| `alpaca` > `customCodeCopsForTestApps` | string[] | [`customCodeCops`](https://aka.ms/algosettings#customCodeCops) | workflow | Overrides `customCodeCops` for test app builds. If set to an empty array, the `customCodeCops` compilation parameter is removed. |
-| `alpaca` > `rulesetFileForTestApps` | string | [`rulesetFile`](https://aka.ms/algosettings#rulesetFile) | workflow | Overrides `rulesetFile` for test app builds. |
+| `alpaca` > `enableCodeCopForTestApps` | boolean | [`enableCodeCop`](https://aka.ms/algosettings#enablecodecop) | workflow | Overrides `enableCodeCop` for test app builds. |
+| `alpaca` > `enableUICopForTestApps` | boolean | [`enableUICop`](https://aka.ms/algosettings#enableuicop) | workflow | Overrides `enableUICop` for test app builds. |
+| `alpaca` > `enablePerTenantExtensionCopForTestApps` | boolean | [`enablePerTenantExtensionCop`](https://aka.ms/algosettings#enablepertenantextensioncop) | workflow | Overrides `enablePerTenantExtensionCop` for test app builds. |
+| `alpaca` > `enableAppSourceCopForTestApps` | boolean | [`enableAppSourceCop`](https://aka.ms/algosettings#enableappsourcecop) | workflow | Overrides `enableAppSourceCop` for test app builds. |
+| `alpaca` > `customCodeCopsForTestApps` | string[] | [`customCodeCops`](https://aka.ms/algosettings#customcodecops) | workflow | Overrides `customCodeCops` for test app builds. If set to an empty array, the `customCodeCops` compilation parameter is removed. |
+| `alpaca` > `rulesetFileForTestApps` | string | [`rulesetFile`](https://aka.ms/algosettings#rulesetfile) | workflow | Overrides `rulesetFile` for test app builds. |
 
 ### Update of AL-Go Settings Files
 

--- a/docs/en-us/github/setup-al-go-settings.md
+++ b/docs/en-us/github/setup-al-go-settings.md
@@ -169,6 +169,22 @@ Settings to change the behavior of running tests for the build workflows.
 | - | - | - | - | - |
 | `alpaca` > `actionOnMissingTests` | string | `Warning` | workflow | Defines the action for the case where no test was executed for the test apps *(`None`, `Warning`, `Error`)*. |
 
+### Code Analyzers for Test Apps
+
+Settings to override code analyzer settings for test apps and BCPT apps.
+
+> [!NOTE]
+> These settings are only applied when [`enableCodeAnalyzersOnTestApps`](https://aka.ms/algosettings#enablecodeanalyzersontestapps) is enabled.
+
+| Element | Type | Default | Scope | Value |
+| - | - | - | - | - |
+| `alpaca` > `enableCodeCopForTestApps` | boolean | [`enableCodeCop`](https://aka.ms/algosettings#enableCodeCop) | workflow | Overrides `enableCodeCop` for test app builds. |
+| `alpaca` > `enableUICopForTestApps` | boolean | [`enableUICop`](https://aka.ms/algosettings#enableUICop) | workflow | Overrides `enableUICop` for test app builds. |
+| `alpaca` > `enablePerTenantExtensionCopForTestApps` | boolean | [`enablePerTenantExtensionCop`](https://aka.ms/algosettings#enablePerTenantExtensionCop) | workflow | Overrides `enablePerTenantExtensionCop` for test app builds. |
+| `alpaca` > `enableAppSourceCopForTestApps` | boolean | [`enableAppSourceCop`](https://aka.ms/algosettings#enableAppSourceCop) | workflow | Overrides `enableAppSourceCop` for test app builds. |
+| `alpaca` > `customCodeCopsForTestApps` | string[] | [`customCodeCops`](https://aka.ms/algosettings#customCodeCops) | workflow | Overrides `customCodeCops` for test app builds. If set to an empty array, the `customCodeCops` compilation parameter is removed. |
+| `alpaca` > `rulesetFileForTestApps` | string | [`rulesetFile`](https://aka.ms/algosettings#rulesetFile) | workflow | Overrides `rulesetFile` for test app builds. |
+
 ### Update of AL-Go Settings Files
 
 Settings to change the behavior of the workflow "COSMO Alpaca - Update Settings Files".


### PR DESCRIPTION
This pull request updates the documentation to add new settings for configuring code analyzers specifically for test apps and BCPT apps in the build workflows. These settings allow for more granular control over which analyzers are run on test app builds, overriding the general analyzer settings when enabled.

**New code analyzer override settings for test apps:**

* Added a section describing how to override code analyzer settings for test apps and BCPT apps, which only applies if `enableCodeAnalyzersOnTestApps` is enabled.
* Introduced new settings under `alpaca` for test app builds, including:
  * `enableCodeCopForTestApps`
  * `enableUICopForTestApps`
  * `enablePerTenantExtensionCopForTestApps`
  * `enableAppSourceCopForTestApps`
  * `customCodeCopsForTestApps`
  * `rulesetFileForTestApps`
  Each setting allows overriding the corresponding main analyzer setting for test apps.

[AB#4981](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4981)