### PR TITLE
docs: add app dependency inheritance

### DIFF
--- a/docs/en-us/github/setup-al-go-settings.md
+++ b/docs/en-us/github/setup-al-go-settings.md
@@ -27,6 +27,9 @@ All available AL-Go settings are documented in the [AL-Go documentation](https:/
 | `assignPremiumPlan`        | boolean  | `false`                                 | container           | Set `true` to enable premium user experience for the default user of sandbox containers. <br>[AL-Go documentation](https://aka.ms/algosettings#assignPremiumPlan) |
 | `licenseFileUrlSecretName` | string   | `LicenseFileUrl`                        | container           | The name of a GitHub secret containing the URL of the license file. <br>[AL-Go documentation](https://aka.ms/algosettings#licenseFileUrlSecretName) |
 
+> [!NOTE]
+> COSMO Alpaca cannot guarantee support for the AL-Go setting [`updateDependencies`](https://aka.ms/algosettings#updatedependencies) in every case. When enabled, AL-Go sets dependency versions in `app.json` to the exact four-part Business Central version used for compilation. A COSMO Alpaca container might use a slightly different Business Central build than the AL-Go compiler, causing these exact dependency versions to be unavailable in the container.
+
 ### License File
 
 The AL-Go setting `licenseFileUrlSecretName` specifies the GitHub secret name containing the license file URL used by the BC service in the container.
@@ -54,8 +57,8 @@ For this you could set the AL-Go setting `licenseFileUrlSecretName` to a dummy v
     > Only for BC Versions **17.12+**, **18.7+**, **19.1+** or up until **BC22**
 
     - Create a GitHub secret:
-        - Name: `BC_LIC_23_CRONUS`
-        - Value: `https://ccppi.blob.core.windows.net/lic/Cronus.bclicense?sp=r&st=2023-06-08T05:34:31Z&se=2033-08-06T13:34:31Z&spr=https&sv=2022-11-02&sr=b&sig=5Noq50jApcWD4XQOG09v%2BChscfio%2B813Kfim79v88RY%3D`
+      - Name: `BC_LIC_23_CRONUS`
+      - Value: `https://ccppi.blob.core.windows.net/lic/Cronus.bclicense?sp=r&st=2023-06-08T05:34:31Z&se=2033-08-06T13:34:31Z&spr=https&sv=2022-11-02&sr=b&sig=5Noq50jApcWD4XQOG09v%2BChscfio%2B813Kfim79v88RY%3D`
     - Set AL-Go setting `licenseFileUrlSecretName`:
 
       ```json

--- a/docs/en-us/github/setup-artifacts.md
+++ b/docs/en-us/github/setup-artifacts.md
@@ -12,6 +12,11 @@ Two types of artifacts are supported:
 1. [Artifacts from a NuGet feed](#nuget-feed)
 1. [Artifacts from a URL](#url)
 
+## Inherit App Dependencies
+
+The dependencies of your app are automatically detected from your `app.json` files and inherited as NuGet artifacts for the container configuration. If all app dependencies are available as NuGet artifacts within COSMO Alpaca (see [**Packages View**](./packages-view.md)), you do not need to configure them manually.
+Explicitly configured artifacts take precedence over inherited dependencies. If you specify the `version` of an artifact, it overrides the version inherited from `app.json`. The AL-Go setting `nuGetFeedSelectMode` is fully supported when resolving NuGet package versions.
+
 ## Parameters
 
 Optional parameters available for all artifacts:
@@ -36,7 +41,7 @@ By default all Microsoft NuGet feeds are available for AL-Go, but only the feed 
 Trusted NuGet feeds can either be configured in the [AL-Go settings](setup-al-go-settings.md) or per-user by specifying custom nuget feeds in the Alpaca settings in VS Code.
 
 1. Find out the name and version of the NuGet package you want to use (e.g. from the [Packages View](packages-view.md)).
-1. Add the artifact to `alpaca` > `artifacts` in your [AL-Go settings](setup-al-go-settings.md):
+2. Add the artifact to `alpaca` > `artifacts` in your [AL-Go settings](setup-al-go-settings.md):
 
 ```json
 {


### PR DESCRIPTION
This pull request updates the documentation to clarify how app dependencies are handled as NuGet artifacts and to provide important notes about AL-Go settings compatibility. The changes make it clearer how dependencies are inherited and configured, and warn users about potential issues with the `updateDependencies` setting.

**Documentation improvements:**

* Added a section explaining that app dependencies from `app.json` are automatically detected and inherited as NuGet artifacts for container configuration. It also clarifies the precedence of explicitly configured artifacts and support for the `nuGetFeedSelectMode` setting.
* Added a note in the AL-Go settings documentation that COSMO Alpaca cannot guarantee support for the `updateDependencies` setting in all cases, due to possible differences in Business Central builds between the compiler and container.

[AB#4982](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4982)