### PR TITLE
Clarify usage of public URL in onprem deployments

### DIFF
--- a/docs/en-us/github/add-environment.md
+++ b/docs/en-us/github/add-environment.md
@@ -203,7 +203,9 @@ Use `windows-latest` for a GitHub-hosted runner or specify the label of your sel
 }
 ```
 
-Use the public URL when the deployment is executed from a GitHub-hosted runner. If you use a self-hosted runner inside the same network, you can also use an internal address.
+Use the public URL when the deployment is executed from a GitHub-hosted runner. Even if you have a self-hosted runner inside the same network, the public URL should be used to avoid issues due to SSL encryption. If your Business Central OData Service (used for the automation API) is listed under a different port than the default, you need to specify that port in the `apiBaseUrl` as well.
+
+Please note that if a tenant is specified in the AuthContext Secret, the app will only be published for that tenant.
 
 For OnPremise deployments, you can also use authentication through a service principal (requires a correspondingly configured Business Central server). In that case, you need to create a Microsoft Entra app registration. For detailed setup and additional configuration options, see the [AL-Go OnPremise Deployer README](https://github.com/akoniecki/AL-Go-OnPremise-Deployer/blob/main/README.md).
 


### PR DESCRIPTION
This pull request updates the deployment documentation for GitHub Actions runners. The main changes clarify the recommended use of public URLs for deployments, address SSL-related issues, and provide guidance on specifying tenants and custom ports.

Deployment instructions and configuration:

* Updated guidance to always use the public URL for deployments, even with self-hosted runners, to prevent SSL encryption issues. Also added instructions to specify a custom port in `apiBaseUrl` if the OData Service uses a non-default port.
* Added a note that if a tenant is specified in the AuthContext Secret, the app will only be published for that tenant.